### PR TITLE
Add symbolizing of maps within lists

### DIFF
--- a/lib/better_params.ex
+++ b/lib/better_params.ex
@@ -66,7 +66,7 @@ defmodule BetterParams do
     |> Map.merge(map)
   end
 
-
+  defp symbolize_keys(list) when is_list(list), do: Enum.map(list, &symbolize_keys/1)
   defp symbolize_keys(map) when is_map(map) do
     Enum.reduce map, %{}, fn {k, v}, m ->
       v = case v do

--- a/lib/better_params.ex
+++ b/lib/better_params.ex
@@ -69,15 +69,10 @@ defmodule BetterParams do
   defp symbolize_keys(list) when is_list(list), do: Enum.map(list, &symbolize_keys/1)
   defp symbolize_keys(map) when is_map(map) do
     Enum.reduce map, %{}, fn {k, v}, m ->
-      v = case v do
-        v when is_map(v)  -> symbolize_keys(v)
-        v when is_list(v) -> Enum.map(v, &symbolize_keys/1)
-        v -> v
-      end
-
-      map_put(m, k, v)
+      map_put(m, k, symbolize_keys(v))
     end
   end
+  defp symbolize_keys(term), do: term
 
 
   defp map_put(map, k, v) when is_map(map) do

--- a/lib/better_params.ex
+++ b/lib/better_params.ex
@@ -69,9 +69,10 @@ defmodule BetterParams do
 
   defp symbolize_keys(map) when is_map(map) do
     Enum.reduce map, %{}, fn {k, v}, m ->
-      v = case is_map(v) do
-        true  -> symbolize_keys(v)
-        false -> v
+      v = case v do
+        v when is_map(v)  -> symbolize_keys(v)
+        v when is_list(v) -> Enum.map(v, &symbolize_keys/1)
+        v -> v
       end
 
       map_put(m, k, v)

--- a/test/better_params_test.exs
+++ b/test/better_params_test.exs
@@ -20,7 +20,12 @@ defmodule BetterParams.Tests do
     assert BetterParams.symbolize_merge(m_before) == m_after
   end
 
+  test "#symbolize_merge deep symbolizes lists of maps" do
+    m_before = %{"a" => 1, "b" => %{"c" => 2, "d" => "3", "e" => [%{"f" => 4}, %{"g" => "5"}]}}
+    m_after  = Map.merge(m_before, %{a: 1, b: %{c: 2, d: "3", e: [%{f: 4}, %{g: "5"}]}})
 
+    assert BetterParams.symbolize_merge(m_before) == m_after
+  end
 
   @opts Router.init([])
   test "params map has both atom and string keys" do

--- a/test/better_params_test.exs
+++ b/test/better_params_test.exs
@@ -27,6 +27,13 @@ defmodule BetterParams.Tests do
     assert BetterParams.symbolize_merge(m_before) == m_after
   end
 
+  test "#symbolize_merge leaves non-map terms in lists untouched" do
+    m_before = %{"a" => [1, 2, %{"b" => 3}]}
+    m_after = Map.merge(m_before, %{a: [1, 2, %{b: 3}]})
+
+    assert BetterParams.symbolize_merge(m_before) == m_after
+  end
+
   @opts Router.init([])
   test "params map has both atom and string keys" do
     params =


### PR DESCRIPTION
To remain consistent, maps within lists should also have their keys symbolized.

Any thoughts?