### PR TITLE
Add option to drop String keys entirely.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,26 @@ end
 
 ```
 
+
+
+### Removing String Keys Entirely
+
+If your use case calls for a params object with _only_ `Atom` keys, you may pass the option `drop_string_keys` to the plug. Much as it says on the can, this will replace the `String`-type keys altogether, rather than preserving them alongside the `Atom` keys.
+
+```elixir
+defmodule MyApp.Router do
+  use Plug.Router
+
+  plug :match
+  plug :dispatch
+  plug BetterParams,
+    drop_string_keys: true
+
+  # Rest of the router...
+end
+
+```
+
 <br>
 
 
@@ -168,5 +188,3 @@ This package is available as open source under the terms of the [MIT License][li
 
   [github-fork]:      https://github.com/sheharyarn/better_params/fork
   [gh-issue-ddos]:    https://github.com/sheharyarn/better_params/issues/1
-
-

--- a/lib/better_params.ex
+++ b/lib/better_params.ex
@@ -13,11 +13,12 @@ defmodule BetterParams do
   @doc """
   Initializes the Plug.
 
-  This plug doesn't take any arguments.
+
   """
-  @spec init(term :: term) :: :ok
-  def init(_) do
-    :ok
+  @spec init(term :: term) :: {boolean}
+  def init(opts) do
+    drop_string_keys = Keyword.get(opts, :drop_string_keys, false)
+    {drop_string_keys}
   end
 
 
@@ -27,12 +28,12 @@ defmodule BetterParams do
   Implementation of the Plug
 
   This implements the `call` callback of the Plug. It calls the
-  `symbolize_merge/1` method on the `Plug.Conn` params map, so
+  `symbolize_merge/2` method on the `Plug.Conn` params map, so
   they are available both with String and Atom keys.
   """
-  @spec call(conn :: Plug.Conn.t, :ok) :: Plug.Conn.t
-  def call(%{params: params} = conn, :ok) do
-    %{ conn | params: symbolize_merge(params) }
+  @spec call(conn :: Plug.Conn.t, opts :: {boolean}) :: Plug.Conn.t
+  def call(%{params: params} = conn, {drop_string_keys}) do
+    %{ conn | params: symbolize_merge(params, drop_string_keys) }
   end
 
 
@@ -42,7 +43,8 @@ defmodule BetterParams do
   Core logic of the Plug
 
   Takes a Map with String keys and returns a new map with
-  all values accessible by both String and Atom keys.
+  all values accessible by both String and Atom keys, or,
+  if the second parameter is `true`, by Atom keys only.
 
   If the map is nested, it symbolizes all sub-maps
   as well.
@@ -52,20 +54,28 @@ defmodule BetterParams do
   ```
   map = %{"a" => 1, "b" => %{"c" => 2, "d" => 3}}
 
-  map = BetterParams.symbolize_merge(map)
+  string_map = BetterParams.symbolize_merge(map, false)
   # => %{:a => 1, :b => %{c: 2, d: 3}, "a" => 1, "b" => %{"c" => 2, "d" => 3}}
 
-  map[:a]           # => 1
-  map[:b][:c]       # => 2
-  map.b.d           # => 3
+  atom_map = BetterParams.symbolize_merge(map, true)
+  # => %{:a => 1, :b => %{c: 2, d: 3}}
+
+  string_map[:a]           # => 1
+  string_map[:b][:c]       # => 2
+  string_map.b.d           # => 3
   ```
   """
-  @spec symbolize_merge(map :: map) :: map
-  def symbolize_merge(map) when is_map(map) do
-    map
-    |> Map.delete(:__struct__)
-    |> symbolize_keys
-    |> Map.merge(map)
+  @spec symbolize_merge(map :: map, drop_string_keys :: boolean) :: map
+  def symbolize_merge(map, drop_string_keys) when is_map(map) do
+    atom_map = map
+              |> Map.delete(:__struct__)
+              |> symbolize_keys
+
+    if drop_string_keys do
+      atom_map
+    else
+      Map.merge(map, atom_map)
+    end
   end
 
 

--- a/lib/better_params.ex
+++ b/lib/better_params.ex
@@ -15,10 +15,9 @@ defmodule BetterParams do
 
 
   """
-  @spec init(term :: term) :: {boolean}
+  @spec init(opts :: Keyword.t) :: Keyword.t
   def init(opts) do
-    drop_string_keys = Keyword.get(opts, :drop_string_keys, false)
-    {drop_string_keys}
+    opts
   end
 
 
@@ -31,9 +30,9 @@ defmodule BetterParams do
   `symbolize_merge/2` method on the `Plug.Conn` params map, so
   they are available both with String and Atom keys.
   """
-  @spec call(conn :: Plug.Conn.t, opts :: {boolean}) :: Plug.Conn.t
-  def call(%{params: params} = conn, {drop_string_keys}) do
-    %{ conn | params: symbolize_merge(params, drop_string_keys) }
+  @spec call(conn :: Plug.Conn.t, opts :: Keyword.t) :: Plug.Conn.t
+  def call(%{params: params} = conn, opts) do
+    %{ conn | params: symbolize_merge(params, opts) }
   end
 
 
@@ -65,13 +64,14 @@ defmodule BetterParams do
   string_map.b.d           # => 3
   ```
   """
-  @spec symbolize_merge(map :: map, drop_string_keys :: boolean) :: map
-  def symbolize_merge(map, drop_string_keys) when is_map(map) do
-    atom_map = map
-              |> Map.delete(:__struct__)
-              |> symbolize_keys
+  @spec symbolize_merge(map :: map, opts :: Keyword.t) :: map
+  def symbolize_merge(map, opts) when is_map(map) do
+    atom_map =
+      map
+      |> Map.delete(:__struct__)
+      |> symbolize_keys
 
-    if drop_string_keys do
+    if Keyword.get(opts, :drop_string_keys, false) do
       atom_map
     else
       Map.merge(map, atom_map)

--- a/test/better_params_test.exs
+++ b/test/better_params_test.exs
@@ -17,7 +17,7 @@ defmodule BetterParams.Tests do
       m_before = %{"a" => 1, "b" => 2, "c" => "3"}
       m_after  = Map.merge(m_before, %{a: 1, b: 2, c: "3"})
 
-      assert BetterParams.symbolize_merge(m_before, false) == m_after
+      assert BetterParams.symbolize_merge(m_before, []) == m_after
     end
 
 
@@ -25,7 +25,7 @@ defmodule BetterParams.Tests do
       m_before = %{"a" => 1, "b" => %{"c" => 2, "d" => "3"}}
       m_after  = Map.merge(m_before, %{a: 1, b: %{c: 2, d: "3"}})
 
-      assert BetterParams.symbolize_merge(m_before, false) == m_after
+      assert BetterParams.symbolize_merge(m_before, []) == m_after
     end
 
 
@@ -33,7 +33,7 @@ defmodule BetterParams.Tests do
       m_before = %{"a" => 1, "b" => %{"c" => 2, "d" => "3", "e" => [%{"f" => 4}, %{"g" => "5"}]}}
       m_after  = Map.merge(m_before, %{a: 1, b: %{c: 2, d: "3", e: [%{f: 4}, %{g: "5"}]}})
 
-      assert BetterParams.symbolize_merge(m_before, false) == m_after
+      assert BetterParams.symbolize_merge(m_before, []) == m_after
     end
 
 
@@ -41,14 +41,14 @@ defmodule BetterParams.Tests do
       m_before = %{"a" => [1, 2, %{"b" => 3}]}
       m_after = Map.merge(m_before, %{a: [1, 2, %{b: 3}]})
 
-      assert BetterParams.symbolize_merge(m_before, false) == m_after
+      assert BetterParams.symbolize_merge(m_before, []) == m_after
     end
 
 
     test "it ignores structs" do
       params = %{ file: Helpers.build_upload("some/file") }
 
-      assert BetterParams.symbolize_merge(params, false) == params
+      assert BetterParams.symbolize_merge(params, []) == params
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -27,10 +27,26 @@ defmodule BetterParams.Tests.Meta do
     end
   end
 
+  # String-dropping Router to test our Plug against
+  defmodule AtomRouter do
+    use Plug.Router
+
+    plug :match
+    plug :dispatch
+    plug BetterParams,
+      drop_string_keys: true
+
+    get "/test/:a/:b/:c" do
+      send_resp(conn, 200, "ok")
+    end
+
+    post "/test/upload/:id" do
+      send_resp(conn, 200, "ok")
+    end
+  end
 end
 
 
 
 # Run our tests
 ExUnit.start()
-

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -33,8 +33,7 @@ defmodule BetterParams.Tests.Meta do
 
     plug :match
     plug :dispatch
-    plug BetterParams,
-      drop_string_keys: true
+    plug BetterParams, drop_string_keys: true
 
     get "/test/:a/:b/:c" do
       send_resp(conn, 200, "ok")


### PR DESCRIPTION
In an effort to resolve my own complaint, this PR adds an option to the Plug that will prevent `better_params` from merging the original string keys back into the atom-keyed map it's generated. I'm still getting my feet wet with Elixir, so I welcome feedback if anything isn't completely idiomatic or if the tack I took is too clumsy!

Closes #5.